### PR TITLE
pass in different github repos as target

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ This folder contains:
 1. Install node / npm
 2. Clone this repository
 3. Run `npm install`
-4. Run `node utilties/index.js [REDCAP API URL] [REDCAP API TOKEN] [GITHUB TOKEN] [type] [LANGUAGE]`
+4. Run `node utilties/index.js [REDCAP API URL] [REDCAP API TOKEN] [GITHUB TOKEN] [type] [LANGUAGE] [GITHUB REPO OWNER] [GITHUB REPO NAME] [GITHUB REPO DIR]`

--- a/generateARMTs.sh
+++ b/generateARMTs.sh
@@ -1,7 +1,7 @@
-source .env
-#node utilities/index.js $REDCAP_API_URL $DA_REDCAP_API_TOKEN $GITHUB_TOKEN aRMT $DA_LANG
-#node utilities/index.js $REDCAP_API_URL $DE_REDCAP_API_TOKEN $GITHUB_TOKEN aRMT $DE_LANG
-#node utilities/index.js $REDCAP_API_URL $EN_REDCAP_API_TOKEN $GITHUB_TOKEN aRMT $EN_LANG
-#node utilities/index.js $REDCAP_API_URL $ES_REDCAP_API_TOKEN $GITHUB_TOKEN aRMT $ES_LANG
-node utilities/index.js $REDCAP_API_URL $IT_REDCAP_API_TOKEN $GITHUB_TOKEN aRMT $IT_LANG
-#node utilities/index.js $REDCAP_API_URL $NL_REDCAP_API_TOKEN $GITHUB_TOKEN aRMT $NL_LANG
+source .env                                                                                                                                                                                                                                                                                                                                                                                                                       
+node utilities/index.js $REDCAP_API_URL $DA_REDCAP_API_TOKEN $GITHUB_TOKEN aRMT $DA_LANG $GITHUB_REPO_OWNER $GITHUB_REPO_NAME $GITHUB_REPO_DIR
+node utilities/index.js $REDCAP_API_URL $DE_REDCAP_API_TOKEN $GITHUB_TOKEN aRMT $DE_LANG $GITHUB_REPO_OWNER $GITHUB_REPO_NAME $GITHUB_REPO_DIR
+node utilities/index.js $REDCAP_API_URL $EN_REDCAP_API_TOKEN $GITHUB_TOKEN aRMT '' $GITHUB_REPO_OWNER $GITHUB_REPO_NAME $GITHUB_REPO_DIR       # only seems to work with a literal for EN_LANG
+node utilities/index.js $REDCAP_API_URL $ES_REDCAP_API_TOKEN $GITHUB_TOKEN aRMT $ES_LANG $GITHUB_REPO_OWNER $GITHUB_REPO_NAME $GITHUB_REPO_DIR 
+node utilities/index.js $REDCAP_API_URL $IT_REDCAP_API_TOKEN $GITHUB_TOKEN aRMT $IT_LANG $GITHUB_REPO_OWNER $GITHUB_REPO_NAME $GITHUB_REPO_DIR 
+node utilities/index.js $REDCAP_API_URL $NL_REDCAP_API_TOKEN $GITHUB_TOKEN aRMT $NL_LANG $GITHUB_REPO_OWNER $GITHUB_REPO_NAME $GITHUB_REPO_DIR

--- a/utilities/_.env-template
+++ b/utilities/_.env-template
@@ -15,13 +15,18 @@ NL_REDCAP_API_TOKEN=''
 #https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/
 #use a personal github token for your account
 GITHUB_TOKEN=''
+GITHUB_REPO_OWNER=''
+GITHUB_REPO_NAME=''
+GITHUB_REPO_DIR=''
+
+
 
 TYPE='aRMT'
 
 EN_LANG=''
-DA_LANG='da'
-DE_LANG='de'
-ES_LANG='es'
-IT_LANG='it'
-NL_LANG='nl'
+DA_LANG='_da'
+DE_LANG='_de'
+ES_LANG='_es'
+IT_LANG='_it'
+NL_LANG='_nl'
 

--- a/utilities/index.js
+++ b/utilities/index.js
@@ -109,7 +109,7 @@ function REDCapConvertor(redcap_json) {
 
 }
 
-function postToGitHub (github_token, filename, file_content) {
+function postToGitHub (github_token, filename, file_content, github_repo_owner, github_repo_name, github_repo_dir) {
 
   var github = new GitHubApi()
 
@@ -120,9 +120,9 @@ function postToGitHub (github_token, filename, file_content) {
   })
 
   var github_details = {
-      owner: 'RADAR-base',
-      repo: 'RADAR-REDCap-aRMT-Definitions',
-      path: 'questionnaires/'+ filename
+      owner: github_repo_owner,
+      repo: github_repo_name,
+      path: github_repo_dir + '/' + filename
   };
 
   var post_details = {
@@ -163,16 +163,16 @@ function splitIntoQuestionnaires(armt_json) {
   return questionnaires
 }
 
-function preparePostToGithub(form_name, form, lang, github_token) {
+function preparePostToGithub(form_name, form, lang, github_token, github_repo_owner, github_repo_name, github_repo_dir) {
   console.log(lang + ' ' + form_name)
   postToGitHub(github_token,
     form_name + "/"+ form_name + "_armt" + lang + ".json",
-    JSON.stringify(form,null,4)
+    JSON.stringify(form,null,4), github_repo_owner, github_repo_name, github_repo_dir
   );
 }
 
-function postRADARJSON(redcap_url, redcap_token, github_token, type, langConvention) {
-    var lang = "_" + langConvention || '';
+function postRADARJSON(redcap_url, redcap_token, github_token, type, langConvention, github_repo_owner, github_repo_name, github_repo_dir) {
+    var lang = langConvention || '';
     var redcap_url = redcap_url || '';
     var redcap_token = redcap_token || '';
     var redcap_form_name = redcap_form_name || '';
@@ -198,20 +198,20 @@ function postRADARJSON(redcap_url, redcap_token, github_token, type, langConvent
         form_armt = armt_json_questionnaires[form_name]
         form_redcap = redcap_json_questionnaires[form_name]
         switch(type) {
-          case 'redcap': preparePostToGithub(form_name, form_redcap, lang, github_token)
+          case 'redcap': preparePostToGithub(form_name, form_redcap, lang, github_token, github_repo_owner, github_repo_name, github_repo_dir)
 
-          default: preparePostToGithub(form_name, form_armt, lang, github_token)
+          default: preparePostToGithub(form_name, form_armt, lang, github_token, github_repo_owner, github_repo_name, github_repo_dir)
           break;
         }
         globalItter += 1
         if (globalItter == form_names.length) {
           // Wait further 2000ms for asynchronous tasks to be completed
-          new Promise(resolve => setTimeout(resolve, 2000)).then(() => { process.exit()});
+          new Promise(resolve => setTimeout(resolve, 1500)).then(() => { process.exit()});
         }
-      }, 2000)
+      }, 3000)
     });
 }
 
 var globalItter = 0
 var args = process.argv.slice(2);
-postRADARJSON(args[0], args[1], args[2], args[3], args[4]);
+postRADARJSON(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7]);


### PR DESCRIPTION
Update the utilities/index.js script for generating the aRMT questionnaires from REDCap instruments
- [x] fix failing english version conversion 
- [x] add option to target different github repos (e.g. a private test repo) rather than hardcoded to one 
- [ ] add option to target different branch rather than master, in this way new changes should be done with PRs rather than direct-to-master pushes

still some issues around asynchronous premature termination - temporary fix by just increasing the timeout but this should be fixed properly later